### PR TITLE
Use a URL for database connections instead of multiple config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,5 @@ Environment variables are used for configuration (which can also be set in `.env
 Example config file: 
 
 ```sh
-## Default values
-REDIS_HOST="localhost"
-REDIS_PORT=6379
-REDIS_DB=0
-
-## No values by default
-#REDIS_PASSWORD="123456"
-#REDIS_USERNAME="user"
+REDIS_URL="redis://user:password@server/db"
 ```

--- a/example.env
+++ b/example.env
@@ -1,6 +1,1 @@
-# Default values
-REDIS_HOST="localhost"
-REDIS_PORT=6379
-REDIS_DB=0
-REDIS_PASSWORD="123456"
-REDIS_USERNAME="user"
+REDIS_URL="redis://user:password@server/db"

--- a/scoretracker/deps.py
+++ b/scoretracker/deps.py
@@ -22,4 +22,7 @@ def get_settings() -> Settings:
 @lru_cache
 def get_redis() -> Redis:
     settings = get_settings()
-    return Redis.from_url(settings.REDIS_URL, decode_responses=True)
+    if settings.REDIS_URL is None:
+        return Redis(decode_responses=True)
+    else:
+        return Redis.from_url(settings.REDIS_URL, decode_responses=True)

--- a/scoretracker/deps.py
+++ b/scoretracker/deps.py
@@ -22,11 +22,4 @@ def get_settings() -> Settings:
 @lru_cache
 def get_redis() -> Redis:
     settings = get_settings()
-    return Redis(
-        host=settings.REDIS_HOST,
-        port=settings.REDIS_PORT,
-        db=settings.REDIS_DB,
-        password=settings.REDIS_PASSWORD,
-        username=settings.REDIS_USERNAME,
-        decode_responses=True
-    )
+    return Redis.from_url(settings.REDIS_URL, decode_responses=True)

--- a/scoretracker/utils.py
+++ b/scoretracker/utils.py
@@ -4,15 +4,12 @@ Utility functions.
 
 from typing import Optional
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, RedisDsn
+from redis import Redis
 
 
 class Settings(BaseSettings):
     class Config:
         env_file = ".env"
 
-    REDIS_HOST: str = "localhost"
-    REDIS_PORT: int = 6379
-    REDIS_DB: int = 0
-    REDIS_PASSWORD: Optional[str] = None
-    REDIS_USERNAME: Optional[str] = None
+    REDIS_URL: Optional[RedisDsn] = None

--- a/scoretracker/utils.py
+++ b/scoretracker/utils.py
@@ -5,7 +5,6 @@ Utility functions.
 from typing import Optional
 
 from pydantic import BaseSettings, RedisDsn
-from redis import Redis
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
This takes advantages of features built into both `pydantic` and `redis-py`. 

I'm sending this as a pull request because I've yet to see if this breaks anything.